### PR TITLE
Fixing issue #2

### DIFF
--- a/pac
+++ b/pac
@@ -161,7 +161,7 @@ def autoremove():
     """
     orphans: List[str] = run(['pacaur', '-Qdtq'], stdout=PIPE).stdout.decode().split('\n')
     if orphans != ['', ]:
-        call(f'pacaur -Rs {" ".join(orphans)}')
+        call(f'pacaur -Rs {" ".join(orphans)}', shell=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is not an ideal solution. Subprocess seems to have issues with long lists of parameters without initialising a new shell context. From experimentation it seems that shell context *is* unfortunately required here to make it work though.